### PR TITLE
Makefile & changes to docker

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+.env
 # Python-generated files
 __pycache__/
 *.py[oc]

--- a/Dockerfile
+++ b/Dockerfile
@@ -27,6 +27,4 @@ RUN /usr/local/bin/uv sync
 # ENV USER=MIKE
 # ENV PGPASS=Secret123
 
-ENTRYPOINT [ "streamlit", "run", "/app/app.py" ] 
-
-EXPOSE 8501
+CMD [ "streamlit", "run", "/app/app.py" ] 

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,35 @@
+IMAGE_NAME=url_lal_app
+COMMON_DOCKER_OPTIONS=--env-file .env \
+		-v $(PWD)/app:/app/src \
+
+
+.PHONY=build run inter check_env_file
+
+check_env_file:
+	@if [ ! -f .env ]; then \
+		echo "Error: .env file not found!"; \
+		exit 1; \
+	fi
+	@if ! grep -q "PGPASS=" .env; then \
+		echo "Error: PGPASS not found in .env file!"; \
+		exit 1; \
+	fi
+	@if ! grep -q "USER=" .env; then \
+		echo "Error: USER not found in .env file!"; \
+		exit 1; \
+	fi
+
+build: 
+	docker build . -t $(IMAGE_NAME)
+
+run: check_env_file build
+	docker run -p 8501:8501 \
+		$(COMMON_DOCKER_OPTIONS) \
+		$(IMAGE_NAME)
+
+inter: check_env_file build
+	docker run -it \
+		$(COMMON_DOCKER_OPTIONS) \
+		$(IMAGE_NAME) \
+		/bin/bash
+


### PR DESCRIPTION
Some light changes to allow for make.

- added .env files for putting env vars (pgpass etc)
- light checking to make sure complete
- changed ENTRYPOINT to CMD so that can be over run w/ interactive session.
- Removed EXPOSE (does nothing and bothers me for some reason).


How to use:
1. Create .env file in root and add pg creds to it. 
2. `make run` <- will build and run (streamlit)
3. `make inter` <- will spin up an interactive session (`bash`) which I find helpful for debugging